### PR TITLE
add delay to prevent asking tool before the finish of initialize

### DIFF
--- a/utils/mcp_client.py
+++ b/utils/mcp_client.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import time
 from queue import Queue, Empty
 from threading import Event, Thread
 from typing import Any
@@ -123,6 +124,7 @@ class McpClient:
             "params": {}
         }
         self.send_message(notify_data)
+        time.sleep(0.1)
 
     def list_tools(self):
         tools_data = {


### PR DESCRIPTION
when i try to connect to my local homeassistant sse server， i got issue connecting the mcp. the error message is pasted below. After i add a delay, the problem has been resolved on my local machine.
![WeCom20250407-161704](https://github.com/user-attachments/assets/84a02177-1a18-41d0-bba5-09aaa53099ca)
