### PR TITLE
Add: follow redirect when request

### DIFF
--- a/utils/mcp_client.py
+++ b/utils/mcp_client.py
@@ -109,7 +109,8 @@ class McpSseClient(McpClient):
             url=self.endpoint_url,
             json=data,
             headers={'Content-Type': 'application/json', 'trace-id': data["id"] if "id" in data else ""},
-            timeout=self.timeout
+            timeout=self.timeout,
+            follow_redirects=True
         )
         response.raise_for_status()
         logging.debug(f"{self.name} - Client message sent successfully: {response.status_code}")
@@ -231,7 +232,8 @@ class McpStreamableHttpClient(McpClient):
             url=self.url,
             json=data,
             headers=headers,
-            timeout=self.timeout
+            timeout=self.timeout,
+            follow_redirects=True
         )
         self.session_id = response.headers.get("mcp-session-id", None)
         content_type = response.headers.get("content-type", "None")


### PR DESCRIPTION
In my case, I was encountering a redirect issue with the FastMCP Python module.
Adding follow_redirects=True resolved the problem.

<img width="437" alt="Screenshot 2025-05-22 at 19 09 02" src="https://github.com/user-attachments/assets/ff8e34ef-7d67-4e7a-9353-84d38887df9f" />

<img width="1175" alt="Screenshot 2025-05-22 at 19 01 29" src="https://github.com/user-attachments/assets/d16b0a2d-4eb3-4c79-b59b-b64e89d9ac60" />

fixed #75