### PR TITLE
feat: support "MCP Servers config" configuring during use

### DIFF
--- a/tools/mcp_call_tool.py
+++ b/tools/mcp_call_tool.py
@@ -12,7 +12,7 @@ from utils.mcp_client import McpClients
 class McpTool(Tool):
 
     def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage]:
-        servers_config_json = self.runtime.credentials.get("servers_config", "")
+        servers_config_json = tool_parameters.get("servers_config") or self.runtime.credentials.get("servers_config")
         if not servers_config_json:
             raise ValueError("Please fill in the servers_config")
         try:

--- a/tools/mcp_call_tool.yaml
+++ b/tools/mcp_call_tool.yaml
@@ -35,3 +35,15 @@ parameters:
       zh_Hans: 工具的参数。
     llm_description: Tool arguments (JSON string in the python dict[str, Any] format).
     form: llm
+  - name: servers_config
+    type: string
+    required: false
+    label:
+      en_US: MCP Servers config
+      zh_Hans: MCP 服务配置
+    human_description:
+      en_US: MCP Servers config, support multiple MCP services. 
+        (Optional, Filling in this field will overwrite the MCP Servers config entered during authorization.)
+      zh_Hans: MCP服务配置，支持多个MCP服务。
+        （选填，填写后将覆盖授权时填写的MCP服务配置。）
+    form: llm

--- a/tools/mcp_list_tools.py
+++ b/tools/mcp_list_tools.py
@@ -12,7 +12,7 @@ from utils.mcp_client import McpClients
 class McpTool(Tool):
 
     def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage]:
-        servers_config_json = self.runtime.credentials.get("servers_config", "")
+        servers_config_json = tool_parameters.get("servers_config") or self.runtime.credentials.get("servers_config")
         if not servers_config_json:
             raise ValueError("Please fill in the servers_config")
         try:

--- a/tools/mcp_list_tools.yaml
+++ b/tools/mcp_list_tools.yaml
@@ -12,3 +12,16 @@ description:
 extra:
   python:
     source: tools/mcp_list_tools.py
+parameters:
+  - name: servers_config
+    type: string
+    required: false
+    label:
+      en_US: MCP Servers config
+      zh_Hans: MCP 服务配置
+    human_description:
+      en_US: MCP Servers config, support multiple MCP services. 
+        (Optional, Filling in this field will overwrite the MCP Servers config entered during authorization.)
+      zh_Hans: MCP服务配置，支持多个MCP服务。
+        （选填，填写后将覆盖授权时填写的MCP服务配置。）
+    form: llm


### PR DESCRIPTION
MCP Servers config, support multiple MCP services.  (Optional, Filling in this field will overwrite the MCP Servers config entered during authorization.)

![912134c679379efc08897e64c3197f1](https://github.com/user-attachments/assets/cc1cc7ea-9b58-4b7f-b687-5dd1aa254750)

closed #72
closed #76
closed #79